### PR TITLE
Username/group cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Script installation
 ------------
 Install the start script
 ```
-sudo mv sysv/foxpass-radius-agent /etc/init.d/foxpass-radius-agent
+sudo cp sysv/foxpass-radius-agent /etc/init.d/foxpass-radius-agent
 ```
 
 Script usage
@@ -68,7 +68,7 @@ Script installation
 ------------
 Install the control script
 ```
-sudo mv systemd/foxpass-radius-agent.service /lib/systemd/system/
+sudo cp systemd/foxpass-radius-agent.service /lib/systemd/system/
 sudo systemctl enable foxpass-radius-agent.service
 ```
 

--- a/foxpass-radius-agent.py
+++ b/foxpass-radius-agent.py
@@ -259,6 +259,9 @@ def process_request(data, address, secret):
     try:
         username = pkt.get(1)[0]
         logger.info("Auth attempt for '%s'" % (username,))
+        if "@" in username:
+            # we don't expect email addresses - just usernames
+            username = username.split("@")[0]
         try:
             password = pkt.get(2)
             if not password:

--- a/foxpass-radius-agent.py
+++ b/foxpass-radius-agent.py
@@ -226,7 +226,14 @@ def group_match(username):
     headers = {'Authorization': 'Token %s' % get_config_item('api_key') }
     reply = requests.get(get_config_item('api_server', DEFAULT_API_HOST) + '/v1/users/' + username + '/groups/', headers=headers)
     data = reply.json()
-
+    if not data:
+        logger.info("No group data returned for user: %s" % (username))
+        return False
+ 
+    if 'data' not in data:
+        logger.info("Unexpected response for user: %s - %s" % (username, data))
+        return False
+ 
     groups = data['data']
 
     user_set = set()

--- a/systemd/foxpass-radius-agent.service
+++ b/systemd/foxpass-radius-agent.service
@@ -3,7 +3,7 @@ Description=Foxpass RADIUS agent
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/python /usr/local/bin/foxpass-radius-agent.py
+ExecStart=/usr/bin/python -u /usr/local/bin/foxpass-radius-agent.py
 Restart=always
 Type=simple
 User=nobody

--- a/sysv/foxpass-radius-agent
+++ b/sysv/foxpass-radius-agent
@@ -10,7 +10,7 @@
 ### END INIT INFO
 
 dir="/usr/local/bin"
-cmd="python /usr/local/bin/foxpass-radius-agent.py"
+cmd="python -u /usr/local/bin/foxpass-radius-agent.py"
 user=""
 
 name=`basename $0`

--- a/upstart/foxpass-radius-agent.conf
+++ b/upstart/foxpass-radius-agent.conf
@@ -8,5 +8,5 @@ setuid nobody
 setgid nogroup
 
 chdir /usr/local/bin
-exec python /usr/local/bin/foxpass-radius-agent.py
+exec python -u /usr/local/bin/foxpass-radius-agent.py
 respawn


### PR DESCRIPTION
Fixes an error where a non existent user logged in and group filtering was enabled, the script would fail when trying to access "data" from the api call result.

Also, since the API is looking for usernames and not email address, remove the @domain portion of the username of the user enters his email address.

A couple of other minor cleanups.