### PR TITLE
No need to retrieve username from email

### DIFF
--- a/foxpass-radius-agent.py
+++ b/foxpass-radius-agent.py
@@ -279,9 +279,6 @@ def process_request(data, address, secret):
         # [0] is needed because pkt.get returns a list
         username = pkt.get('User-Name')[0]
         logger.info("Auth attempt for '%s'" % (username,))
-        if "@" in username:
-            # we don't expect email addresses - just usernames
-            username = username.split("@")[0]
         try:
             password = pkt.get('Password')
             if not password:


### PR DESCRIPTION
## Description of the change
Rad agent is checking if the input is email or plain username. It's not required as similar checks are being done on the web side.

Test Results:

1. Test with email:

Client request:
```
ubuntu@ip-172-31-29-214:~$ radtest karthik@foxpass.com XXXXXXX localhost 1 0123456789
Sent Access-Request Id 133 from 0.0.0.0:44441 to 127.0.0.1:1812 length 89
	User-Name = "karthik@foxpass.com"
	User-Password = "XXXXXXX"
	NAS-IP-Address = 172.31.29.214
	NAS-Port = 1
	Message-Authenticator = 0x00
	Cleartext-Password = "XXXXXXX"
Received Access-Accept Id 133 from 127.0.0.1:1812 to 127.0.0.1:44441 length 20
```
Server response:
```
ubuntu@ip-172-31-29-214:~/foxpass/foxpass-radius-agent$ python3 foxpass-radius-agent.py
2021-05-11 20:09:27,879 INFO     Listening on port 127.0.0.1:1812
2021-05-11 20:09:31,477 INFO     received 89 bytes from ('127.0.0.1', 44441)
2021-05-11 20:09:31,477 INFO     Auth attempt for 'karthik@foxpass.com'
2021-05-11 20:09:31,478 INFO     API request to https://api.foxpass.com/v1/authn/
2021-05-11 20:09:31,782 INFO     MFA not configured
2021-05-11 20:09:31,783 INFO     Successful auth for 'karthik@foxpass.com'
2021-05-11 20:09:31,785 INFO     sent 20 bytes to ('127.0.0.1', 44441)
```
2. Test with username:

client response:
```
ubuntu@ip-172-31-29-214:~$ radtest karthik XXXXXXX localhost 1 0123456789
Sent Access-Request Id 161 from 0.0.0.0:50340 to 127.0.0.1:1812 length 77
	User-Name = "karthik"
	User-Password = "XXXXXXX"
	NAS-IP-Address = 172.31.29.214
	NAS-Port = 1
	Message-Authenticator = 0x00
	Cleartext-Password = "XXXXXXX"
Received Access-Accept Id 161 from 127.0.0.1:1812 to 127.0.0.1:50340 length 20
```

server response:
```
2021-05-11 20:19:19,668 INFO     received 77 bytes from ('127.0.0.1', 50340)
2021-05-11 20:19:19,669 INFO     Auth attempt for 'karthik'
2021-05-11 20:19:19,669 INFO     API request to https://api.foxpass.com/v1/authn/
2021-05-11 20:19:19,979 INFO     MFA not configured
2021-05-11 20:19:19,979 INFO     Successful auth for 'karthik'
2021-05-11 20:19:19,982 INFO     sent 20 bytes to ('127.0.0.1', 50340)
```

